### PR TITLE
Update raw.js

### DIFF
--- a/lib/types/raw.js
+++ b/lib/types/raw.js
@@ -59,7 +59,7 @@ function raw (options) {
       return
     }
 
-    req.body = req.body || {}
+    req.body = req.body || ''
 
     // skip requests without bodies
     if (!typeis.hasBody(req)) {


### PR DESCRIPTION
raw() parser: if body is empty set it to empty string rather than empty dictionnary.
